### PR TITLE
send dummy data with all calls to usb_device_control

### DIFF
--- a/src/libsddc.c
+++ b/src/libsddc.c
@@ -437,7 +437,7 @@ int sddc_start_streaming(sddc_t *this)
     uint8_t data = 0;
     int ret = usb_device_control(this->usb_device, R820T2STDBY, 0, 0, &data, 1);
     if (ret < 0) {
-      fprintf(stderr, "ERROR - usb_device_control(R820T2STDBY) failed: %i\n", ret);
+      fprintf(stderr, "ERROR - usb_device_control(R820T2STDBY) failed\n");
       return -1;
     }
   }

--- a/src/libsddc.c
+++ b/src/libsddc.c
@@ -169,7 +169,8 @@ FAIL0:
 
 void sddc_close(sddc_t *this)
 {
-  int ret = usb_device_control(this->usb_device, RESETFX3, 0, 0, 0, 0); 
+  uint8_t data = 0;
+  int ret = usb_device_control(this->usb_device, RESETFX3, 0, 0, &data, 1);
   if (ret < 0) {
     fprintf(stderr, "ERROR - usb_device_control(RESETFX3) failed\n");
   }
@@ -433,9 +434,10 @@ int sddc_start_streaming(sddc_t *this)
 
   /* tuner in standby */
   if (this->has_vhf_tuner) {
-    int ret = usb_device_control(this->usb_device, R820T2STDBY, 0, 0, 0, 0);
+    uint8_t data = 0;
+    int ret = usb_device_control(this->usb_device, R820T2STDBY, 0, 0, &data, 1);
     if (ret < 0) {
-      fprintf(stderr, "ERROR - usb_device_control(R820T2STDBY) failed\n");
+      fprintf(stderr, "ERROR - usb_device_control(R820T2STDBY) failed: %i\n", ret);
       return -1;
     }
   }
@@ -465,7 +467,8 @@ int sddc_start_streaming(sddc_t *this)
   }
 
   /* start the producer */
-  ret = usb_device_control(this->usb_device, STARTFX3, 0, 0, 0, 0);
+  uint8_t data = 0;
+  ret = usb_device_control(this->usb_device, STARTFX3, 0, 0, &data, 1);
   if (ret < 0) {
     fprintf(stderr, "ERROR - usb_device_control(STARTFX3) failed\n");
     return -1;
@@ -489,7 +492,8 @@ int sddc_stop_streaming(sddc_t *this)
   }
 
   /* stop the producer */
-  int ret = usb_device_control(this->usb_device, STOPFX3, 0, 0, 0, 0);
+  uint8_t data = 0;
+  int ret = usb_device_control(this->usb_device, STOPFX3, 0, 0, &data, 1);
   if (ret < 0) {
     fprintf(stderr, "ERROR - usb_device_control(STOPFX3) failed\n");
     return -1;


### PR DESCRIPTION
I investigated this in particular for `R820T2STDBY` and `STARTFX3`: The protocol seems to expect at least one (dummy) byte of data along with all these commands. This should match what I found in the ExtIO source code:

https://github.com/ik1xpv/ExtIO_sddc/blob/master/ExtIO_sddc/FX3handler.cpp#L173-L176
https://github.com/ik1xpv/ExtIO_sddc/blob/master/ExtIO_sddc/FX3handler.cpp#L180