### PR TITLE
remove inline dummy data; move R820T2STDBY to calls with dummy data

### DIFF
--- a/src/libsddc.c
+++ b/src/libsddc.c
@@ -169,8 +169,7 @@ FAIL0:
 
 void sddc_close(sddc_t *this)
 {
-  uint8_t data = 0;
-  int ret = usb_device_control(this->usb_device, RESETFX3, 0, 0, &data, 1);
+  int ret = usb_device_control(this->usb_device, RESETFX3, 0, 0, 0, 0);
   if (ret < 0) {
     fprintf(stderr, "ERROR - usb_device_control(RESETFX3) failed\n");
   }
@@ -435,8 +434,7 @@ int sddc_start_streaming(sddc_t *this)
 
   /* tuner in standby */
   if (this->has_vhf_tuner) {
-    uint8_t data = 0;
-    int ret = usb_device_control(this->usb_device, R820T2STDBY, 0, 0, &data, 1);
+    int ret = usb_device_control(this->usb_device, R820T2STDBY, 0, 0, 0, 0);
     if (ret < 0) {
       fprintf(stderr, "ERROR - usb_device_control(R820T2STDBY) failed\n");
       return -1;
@@ -468,8 +466,7 @@ int sddc_start_streaming(sddc_t *this)
   }
 
   /* start the producer */
-  uint8_t data = 0;
-  ret = usb_device_control(this->usb_device, STARTFX3, 0, 0, &data, 1);
+  ret = usb_device_control(this->usb_device, STARTFX3, 0, 0, 0, 0);
   if (ret < 0) {
     fprintf(stderr, "ERROR - usb_device_control(STARTFX3) failed\n");
     return -1;
@@ -493,8 +490,7 @@ int sddc_stop_streaming(sddc_t *this)
   }
 
   /* stop the producer */
-  uint8_t data = 0;
-  int ret = usb_device_control(this->usb_device, STOPFX3, 0, 0, &data, 1);
+  int ret = usb_device_control(this->usb_device, STOPFX3, 0, 0, 0, 0);
   if (ret < 0) {
     fprintf(stderr, "ERROR - usb_device_control(STOPFX3) failed\n");
     return -1;

--- a/src/usb_device.c
+++ b/src/usb_device.c
@@ -366,6 +366,7 @@ int usb_device_control(usb_device_t *this, uint8_t request, uint16_t value,
     case STARTFX3:
     case STOPFX3:
     case RESETFX3:
+    case R820T2STDBY:
       ret = libusb_control_transfer(this->dev_handle, bmWriteRequestType,
                                     request, 0, 0, dummy, sizeof(dummy),
                                     timeout);
@@ -393,7 +394,6 @@ int usb_device_control(usb_device_t *this, uint8_t request, uint16_t value,
     case SI5351ATUNE:    /* ??? */
     case R820T2TUNE:
     case R820T2SETATT:
-    case R820T2STDBY:
     case R820T2SETVGA:
       ret = libusb_control_transfer(this->dev_handle, bmWriteRequestType,
                                     request, value, index, data, length,


### PR DESCRIPTION
as promised: this is mostly a revert of the previous pull request. it does fix R820T2STDBY though by putting it into the list of commands that send dummy data.