### PR TITLE
still having errors while running sddc_stream_test...

### DIFF
--- a/src/streaming.c
+++ b/src/streaming.c
@@ -136,8 +136,9 @@ streaming_t *streaming_open_async(usb_device_t *usb_device, uint32_t frame_size,
     return ret_val;
   }
 
-  /* allocate frames for zerocopy USB bulk transfers */
+   /* allocate frames for zerocopy USB bulk transfers */
   uint8_t **frames = (uint8_t **) malloc(num_frames * sizeof(uint8_t *));
+#if defined (__linux__) && LIBUSB_API_VERSION >= 0x01000105
   for (uint32_t i = 0; i < num_frames; ++i) {
     frames[i] = libusb_dev_mem_alloc(usb_device->dev_handle, frame_size);
     if (frames[i] == 0) {
@@ -148,7 +149,13 @@ streaming_t *streaming_open_async(usb_device_t *usb_device, uint32_t frame_size,
       return ret_val;
     }
   }
-
+#else
+  for (uint32_t i = 0; i < num_frames; ++i) {
+    frames[i] = malloc(num_frames);
+    if (!frames[i])
+      log_error("Memory allocation failed", __func__, __FILE__, __LINE__);
+  }
+#endif
   /* we are good here - create and initialize the streaming */
   streaming_t *this = (streaming_t *) malloc(sizeof(streaming_t));
   this->status = STREAMING_STATUS_READY;
@@ -182,20 +189,33 @@ void streaming_close(streaming_t *this)
 {
   if (this->transfers) {
     for (uint32_t i = 0; i < this->num_frames; ++i) {
-      libusb_free_transfer(this->transfers[i]);
+      if (this->transfers[i]) {
+        libusb_free_transfer(this->transfers[i]);
+      }
     }
     free(this->transfers);
+    this->transfers = NULL;
   }
-  if (this->frames != 0) {
+
+  if (this->frames) {
     for (uint32_t i = 0; i < this->num_frames; ++i) {
-      libusb_dev_mem_free(this->usb_device->dev_handle, this->frames[i],
+      if (this->frames[i]) {
+#if defined (__linux__) && LIBUSB_API_VERSION >= 0x01000105
+        libusb_dev_mem_free(this->usb_device->dev_handle, this->frames[i],
                           this->frame_size);
+#else
+        free(this->frames[i]);
+#endif
+      }
     }
+
     free(this->frames);
-  }
-  free(this);
+    this->frames = NULL;  
+    free(this);
+  } 
   return;
 }
+
 
 
 int streaming_set_sample_rate(streaming_t *this, uint32_t sample_rate)

--- a/src/usb_device.c
+++ b/src/usb_device.c
@@ -732,7 +732,7 @@ static int transfer_image(const uint8_t *image,
         return -1;
       }
       if (!(ret == wLength)) {
-        fprintf(stderr, "ERROR - libusb_control_transfer() returned less bytes than expected - actual=%hu expected=%hu\n", ret, wLength);
+        fprintf(stderr, "ERROR - libusb_control_transfer() returned less bytes than expected - actual=%d expected=%hu\n", ret, wLength);
         return -1;
       }
       data += wLength;


### PR DESCRIPTION
cozy@iMac ~/l/b/src (macos) [SIGSEGV]> ./sddc_stream_test ../../firmware/SDDC_FX3.img 2000000
frame_size = 138240, iso_packets_per_frame = 135
started streaming .. for 3000 ms ..
finished. now stop streaming ..
ERROR - USB error LIBUSB_ERROR_OTHER in streaming_stop at /Users/cozy/libsddc/src/streaming.c:285
ERROR - USB error LIBUSB_ERROR_OTHER in streaming_stop at /Users/cozy/libsddc/src/streaming.c:285